### PR TITLE
Fix genus re-naming step to work in older versions of R version 3.6

### DIFF
--- a/BioLockJ/BioLockJ_R/RScripts_AAS/16S_TaxaClassification/Afshar_16S_TaxaClassification.R
+++ b/BioLockJ/BioLockJ_R/RScripts_AAS/16S_TaxaClassification/Afshar_16S_TaxaClassification.R
@@ -22,9 +22,9 @@ taxa<-read.table(paste0(path,"DADA2/taxForwardReads.txt"),sep="\t",header=TRUE)
 meta<-read.table(metaData,sep="\t",header=TRUE,row.names = 1)
 
 #Modify Escherichia name
-taxa$Genus<-sapply(taxa$Genus,function(x){
-  if (x=="Esherichica/Shigella" & !is.na(x)) return("Escherichia/Shigella")
-  else return(x)})
+taxa$Genus = as.factor(taxa$Genus)
+typoIndex = which(levels(taxa$Genus)=="Esherichica/Shigella")
+levels(taxa$Genus)[typoIndex]="Escherichia/Shigella"
 
 meta$time<-sapply(as.character(meta$title),function(x){
   if (substr(x,1,1)=="P") return(strsplit(x,"_")[[1]][2])

--- a/BioLockJ/BioLockJ_R/RScripts_AAS/16S_TaxaClassification/Assal_16S_TaxaClassification.R
+++ b/BioLockJ/BioLockJ_R/RScripts_AAS/16S_TaxaClassification/Assal_16S_TaxaClassification.R
@@ -19,9 +19,9 @@ taxa<-read.table(paste0(path,"DADA2/taxForwardReads.txt"),sep="\t",header=TRUE)
 meta<-read.table(metaData,sep=",",header=TRUE,row.names = 1)
 
 #Modify Escherichia name
-taxa$Genus<-sapply(taxa$Genus,function(x){
-  if (x=="Esherichica/Shigella" & !is.na(x)) return("Escherichia/Shigella")
-  else return(x)})
+taxa$Genus = as.factor(taxa$Genus)
+typoIndex = which(levels(taxa$Genus)=="Esherichica/Shigella")
+levels(taxa$Genus)[typoIndex]="Escherichia/Shigella"
 
 dada<-dada[match(rownames(meta),rownames(dada)),]
 

--- a/BioLockJ/BioLockJ_R/RScripts_AAS/16S_TaxaClassification/BS_16S_TaxaClassification.R
+++ b/BioLockJ/BioLockJ_R/RScripts_AAS/16S_TaxaClassification/BS_16S_TaxaClassification.R
@@ -19,10 +19,9 @@ taxa<-read.table(paste0(path,"DADA2/taxForwardReads.txt"),sep="\t",header=TRUE)
 meta<-read.table(metaData,sep="\t",header=TRUE,row.names = 1)
 
 #Modify Escherichia name
-taxa$Genus<-sapply(taxa$Genus,function(x){
-  if (x=="Esherichica/Shigella" & !is.na(x)) return("Escherichia/Shigella")
-  else return(x)})
-
+taxa$Genus = as.factor(taxa$Genus)
+typoIndex = which(levels(taxa$Genus)=="Esherichica/Shigella")
+levels(taxa$Genus)[typoIndex]="Escherichia/Shigella"
 
 dada<-dada[match(rownames(meta),rownames(dada)),]
 

--- a/BioLockJ/BioLockJ_R/RScripts_AAS/16S_TaxaClassification/Ilhan_16S_TaxaClassification.R
+++ b/BioLockJ/BioLockJ_R/RScripts_AAS/16S_TaxaClassification/Ilhan_16S_TaxaClassification.R
@@ -19,9 +19,9 @@ taxa<-read.table(paste0(path,"DADA2/taxForwardReads.txt"),sep="\t",header=TRUE)
 meta<-read.table(metaData,sep="\t",header=TRUE,row.names = 1)
 
 #Modify Escherichia name
-taxa$Genus<-sapply(taxa$Genus,function(x){
-  if (x=="Esherichica/Shigella" & !is.na(x)) return("Escherichia/Shigella")
-  else return(x)})
+taxa$Genus = as.factor(taxa$Genus)
+typoIndex = which(levels(taxa$Genus)=="Esherichica/Shigella")
+levels(taxa$Genus)[typoIndex]="Escherichia/Shigella"
 
 dada<-dada[match(rownames(meta),rownames(dada)),]
 


### PR DESCRIPTION
This step already worked in 4.0.2.